### PR TITLE
Move sidecar metrics to dedicated plugin

### DIFF
--- a/apps/vmq_events_sidecar/src/vmq_events_sidecar.app.src
+++ b/apps/vmq_events_sidecar/src/vmq_events_sidecar.app.src
@@ -15,6 +15,7 @@
         {port, 8890},
         {pool_size, 100},
         {backlog_size, 4096},
+        {vmq_metrics_mfa, {vmq_events_sidecar_metrics, metrics, []}},
         {vmq_plugin_hooks, [
             {vmq_events_sidecar_plugin, on_register, 5, []},
             {vmq_events_sidecar_plugin, on_register_failed, 5, []},

--- a/apps/vmq_events_sidecar/src/vmq_events_sidecar_metrics.erl
+++ b/apps/vmq_events_sidecar/src/vmq_events_sidecar_metrics.erl
@@ -1,0 +1,300 @@
+-module(vmq_events_sidecar_metrics).
+
+-behaviour(gen_server).
+
+-export([
+    start_link/0,
+    metrics/0,
+    incr_sidecar_events/1,
+    incr_sidecar_events_error/1,
+    incr_events_sampled/2,
+    incr_events_dropped/2
+]).
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-define(SERVER, ?MODULE).
+
+-define(SIDECAR_EVENTS, sidecar_events).
+-define(SIDECAR_EVENTS_ERROR, sidecar_events_error).
+-define(EVENTS_SAMPLING_TABLE, vmq_events_sidecar_events_sampling).
+
+-define(ON_REGISTER, on_register).
+-define(ON_REGISTER_FAILED, on_register_failed).
+-define(ON_PUBLISH, on_publish).
+-define(ON_SUBSCRIBE, on_subscribe).
+-define(ON_UNSUBSCRIBE, on_unsubscribe).
+-define(ON_DELIVER, on_deliver).
+-define(ON_DELIVERY_COMPLETE, on_delivery_complete).
+-define(ON_OFFLINE_MESSAGE, on_offline_message).
+-define(ON_CLIENT_WAKEUP, on_client_wakeup).
+-define(ON_CLIENT_OFFLINE, on_client_offline).
+-define(ON_CLIENT_GONE, on_client_gone).
+-define(ON_SESSION_EXPIRED, on_session_expired).
+-define(ON_MESSAGE_DROP, on_message_drop).
+
+-record(state, {}).
+-record(metric_def, {
+    type :: atom(),
+    labels :: [metric_label()],
+    id :: metric_id(),
+    name :: atom(),
+    description :: undefined | binary()
+}).
+
+-type metric_def() :: #metric_def{}.
+-type metric_label() :: {atom(), string()}.
+-type metric_id() ::
+    atom()
+    | {atom(), non_neg_integer() | atom()}
+    | {atom(), atom(), atom()}
+    | [{atom(), [{atom(), any()}]}].
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-spec start_link() -> 'ignore' | {'error', _} | {'ok', pid()}.
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+-spec metrics() -> [{metric_def(), non_neg_integer()}].
+metrics() ->
+    MetricDefs = metrics_defs(),
+    IdDef = lists:foldl(
+        fun(#metric_def{id = Id} = MD, Acc) ->
+            maps:put(Id, MD, Acc)
+        end,
+        #{},
+        MetricDefs
+    ),
+    lists:filtermap(
+        fun(#metric_def{id = Id}) ->
+            Val =
+                try
+                    counter_val(Id)
+                catch
+                    _:_ -> 0
+                end,
+            case maps:find(Id, IdDef) of
+                {ok, #metric_def{
+                    type = Type,
+                    labels = Labels,
+                    name = Name,
+                    description = Description
+                }} ->
+                    {true, {Type, Labels, Id, Name, Description, Val}};
+                error ->
+                    lager:warning("unknown metrics id: ~p", [Id]),
+                    false
+            end
+        end,
+        MetricDefs
+    ) ++ events_sampling_metrics().
+
+-spec incr_sidecar_events(atom()) -> ok.
+incr_sidecar_events(HookName) ->
+    incr_item({?SIDECAR_EVENTS, HookName}, 1).
+
+-spec incr_sidecar_events_error(atom()) -> ok.
+incr_sidecar_events_error(HookName) ->
+    incr_item({?SIDECAR_EVENTS_ERROR, HookName}, 1).
+
+-spec incr_events_sampled(atom(), binary() | undefined) -> ok.
+incr_events_sampled(_, undefined) ->
+    ok;
+incr_events_sampled(HookName, Criterion) ->
+    incr_events_sampled_item(HookName, Criterion, sampled).
+
+-spec incr_events_dropped(atom(), binary() | undefined) -> ok.
+incr_events_dropped(_, undefined) ->
+    ok;
+incr_events_dropped(HookName, Criterion) ->
+    incr_events_sampled_item(HookName, Criterion, dropped).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+-spec init(_) -> {ok, #state{}}.
+init([]) ->
+    AllEntries = [Id || #metric_def{id = Id} <- metrics_defs()],
+    NumEntries = length(AllEntries),
+    Idxs = lists:map(fun(Id) -> met2idx(Id) end, AllEntries),
+    NumEntries = length(lists:sort(Idxs)),
+    NumEntries = length(lists:usort(Idxs)),
+
+    ets:new(?EVENTS_SAMPLING_TABLE, [named_table, public, {write_concurrency, true}]),
+
+    case catch persistent_term:get(?MODULE) of
+        {'EXIT', {badarg, _}} ->
+            ARef = atomics:new(2 * NumEntries, [{signed, false}]),
+            persistent_term:put(?MODULE, ARef);
+        _ExistingRef ->
+            ok
+    end,
+    {ok, #state{}}.
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+incr_item(_, 0) ->
+    ok;
+incr_item(Entry, Val) when Val > 0 ->
+    ARef =
+        case get(vmq_events_sidecar_metrics_atomics_ref) of
+            undefined ->
+                Ref = persistent_term:get(?MODULE),
+                put(vmq_events_sidecar_metrics_atomics_ref, Ref),
+                Ref;
+            Ref ->
+                Ref
+        end,
+    atomics:add(ARef, met2idx(Entry), Val).
+
+counter_val(Entry) ->
+    ARef = persistent_term:get(?MODULE),
+    atomics:get(ARef, met2idx(Entry)).
+
+incr_events_sampled_item(HookName, Criterion, Type) ->
+    try
+        ets:update_counter(?EVENTS_SAMPLING_TABLE, {HookName, Criterion, Type}, 1)
+    catch
+        _:_ ->
+            try
+                ets:insert_new(?EVENTS_SAMPLING_TABLE, {{HookName, Criterion, Type}, 0}),
+                incr_events_sampled_item(HookName, Criterion, Type)
+            catch
+                _:_ ->
+                    lager:warning("couldn't initialize sidecar metrics tables", [])
+            end
+    end,
+    ok.
+
+events_sampling_metrics() ->
+    ets:foldl(
+        fun({{HookName, Criterion, Type}, TotalCount}, Acc) ->
+            [
+                {counter, sampling_metric_labels(HookName, Criterion),
+                    sampling_metric_id(HookName, Criterion, Type), sampling_metric_name(Type),
+                    sampling_metric_description(Type), TotalCount}
+                | Acc
+            ]
+        end,
+        [],
+        ?EVENTS_SAMPLING_TABLE
+    ).
+
+sampling_metric_name(sampled) ->
+    vmq_events_sampled;
+sampling_metric_name(dropped) ->
+    vmq_events_dropped.
+
+sampling_metric_description(sampled) ->
+    <<"The number of events sampled due to sampling enabled.">>;
+sampling_metric_description(dropped) ->
+    <<"The number of events dropped due to sampling enabled.">>.
+
+sampling_metric_labels(HookName, Criterion) ->
+    [{hook, atom_to_list(HookName)}, {acl_name, binary_to_list(Criterion)}].
+
+sampling_metric_id(HookName, Criterion, Type) ->
+    [sampling_metric_name(Type) | sampling_metric_labels(HookName, Criterion)].
+
+-spec metrics_defs() -> [metric_def()].
+metrics_defs() ->
+    Hooks = [
+        ?ON_REGISTER,
+        ?ON_REGISTER_FAILED,
+        ?ON_PUBLISH,
+        ?ON_SUBSCRIBE,
+        ?ON_UNSUBSCRIBE,
+        ?ON_DELIVER,
+        ?ON_DELIVERY_COMPLETE,
+        ?ON_OFFLINE_MESSAGE,
+        ?ON_CLIENT_WAKEUP,
+        ?ON_CLIENT_OFFLINE,
+        ?ON_CLIENT_GONE,
+        ?ON_SESSION_EXPIRED,
+        ?ON_MESSAGE_DROP
+    ],
+    [
+        m(
+            counter,
+            [{hook, atom_to_list(Hook)}],
+            {?SIDECAR_EVENTS, Hook},
+            sidecar_events,
+            <<"The number of events sidecar hook attempts.">>
+        )
+     || Hook <- Hooks
+    ] ++
+        [
+            m(
+                counter,
+                [{hook, atom_to_list(Hook)}],
+                {?SIDECAR_EVENTS_ERROR, Hook},
+                sidecar_events_error,
+                <<"The number of times events sidecar hook call failed.">>
+            )
+         || Hook <- Hooks
+        ].
+
+-spec m(atom(), [metric_label()], metric_id(), atom(), binary()) -> metric_def().
+m(Type, Labels, UniqueId, Name, Description) ->
+    #metric_def{
+        type = Type,
+        labels = Labels,
+        id = UniqueId,
+        name = Name,
+        description = Description
+    }.
+
+met2idx({?SIDECAR_EVENTS, ?ON_REGISTER}) -> 1;
+met2idx({?SIDECAR_EVENTS, ?ON_REGISTER_FAILED}) -> 2;
+met2idx({?SIDECAR_EVENTS, ?ON_PUBLISH}) -> 3;
+met2idx({?SIDECAR_EVENTS, ?ON_SUBSCRIBE}) -> 4;
+met2idx({?SIDECAR_EVENTS, ?ON_UNSUBSCRIBE}) -> 5;
+met2idx({?SIDECAR_EVENTS, ?ON_DELIVER}) -> 6;
+met2idx({?SIDECAR_EVENTS, ?ON_DELIVERY_COMPLETE}) -> 7;
+met2idx({?SIDECAR_EVENTS, ?ON_OFFLINE_MESSAGE}) -> 8;
+met2idx({?SIDECAR_EVENTS, ?ON_CLIENT_WAKEUP}) -> 9;
+met2idx({?SIDECAR_EVENTS, ?ON_CLIENT_OFFLINE}) -> 10;
+met2idx({?SIDECAR_EVENTS, ?ON_CLIENT_GONE}) -> 11;
+met2idx({?SIDECAR_EVENTS, ?ON_SESSION_EXPIRED}) -> 12;
+met2idx({?SIDECAR_EVENTS, ?ON_MESSAGE_DROP}) -> 13;
+met2idx({?SIDECAR_EVENTS_ERROR, ?ON_REGISTER}) -> 14;
+met2idx({?SIDECAR_EVENTS_ERROR, ?ON_REGISTER_FAILED}) -> 15;
+met2idx({?SIDECAR_EVENTS_ERROR, ?ON_PUBLISH}) -> 16;
+met2idx({?SIDECAR_EVENTS_ERROR, ?ON_SUBSCRIBE}) -> 17;
+met2idx({?SIDECAR_EVENTS_ERROR, ?ON_UNSUBSCRIBE}) -> 18;
+met2idx({?SIDECAR_EVENTS_ERROR, ?ON_DELIVER}) -> 19;
+met2idx({?SIDECAR_EVENTS_ERROR, ?ON_DELIVERY_COMPLETE}) -> 20;
+met2idx({?SIDECAR_EVENTS_ERROR, ?ON_OFFLINE_MESSAGE}) -> 21;
+met2idx({?SIDECAR_EVENTS_ERROR, ?ON_CLIENT_WAKEUP}) -> 22;
+met2idx({?SIDECAR_EVENTS_ERROR, ?ON_CLIENT_OFFLINE}) -> 23;
+met2idx({?SIDECAR_EVENTS_ERROR, ?ON_CLIENT_GONE}) -> 24;
+met2idx({?SIDECAR_EVENTS_ERROR, ?ON_SESSION_EXPIRED}) -> 25;
+met2idx({?SIDECAR_EVENTS_ERROR, ?ON_MESSAGE_DROP}) -> 26.

--- a/apps/vmq_events_sidecar/src/vmq_events_sidecar_metrics.erl
+++ b/apps/vmq_events_sidecar/src/vmq_events_sidecar_metrics.erl
@@ -219,7 +219,7 @@ sampling_metric_description(dropped) ->
     <<"The number of events dropped due to sampling enabled.">>.
 
 sampling_metric_labels(HookName, Criterion) ->
-    [{hook, atom_to_list(HookName)}, {acl_name, binary_to_list(Criterion)}].
+    [{hook, atom_to_list(HookName)}, {acl_name, Criterion}].
 
 sampling_metric_id(HookName, Criterion, Type) ->
     [sampling_metric_name(Type) | sampling_metric_labels(HookName, Criterion)].

--- a/apps/vmq_events_sidecar/src/vmq_events_sidecar_plugin.erl
+++ b/apps/vmq_events_sidecar/src/vmq_events_sidecar_plugin.erl
@@ -462,7 +462,7 @@ send_event(HookName, EventPayload, Criterion) ->
         [] ->
             next;
         [{_}] ->
-            vmq_metrics:incr_sidecar_events(HookName),
+            vmq_events_sidecar_metrics:incr_sidecar_events(HookName),
             case sample(HookName, Criterion) of
                 true ->
                     process_event(HookName, EventPayload);
@@ -515,7 +515,7 @@ process_event(HookName, EventPayload) ->
             ok;
         {error, Reason} ->
             lager:error("Error sending event(shackle:cast): ~p", [Reason]),
-            vmq_metrics:incr_sidecar_events_error(HookName)
+            vmq_events_sidecar_metrics:incr_sidecar_events_error(HookName)
     end,
     V2 = vmq_util:ts(),
     vmq_metrics:pretimed_measurement({vmq_events_sidecar, call_latency}, V2 - V1).
@@ -542,10 +542,10 @@ check(Hook, Criterion) ->
         [{_, P}] ->
             case P >= rand:uniform(100) of
                 true ->
-                    vmq_metrics:incr_events_sampled(Hook, Criterion),
+                    vmq_events_sidecar_metrics:incr_events_sampled(Hook, Criterion),
                     true;
                 _ ->
-                    vmq_metrics:incr_events_dropped(Hook, Criterion),
+                    vmq_events_sidecar_metrics:incr_events_dropped(Hook, Criterion),
                     false
             end
     end.

--- a/apps/vmq_events_sidecar/src/vmq_events_sidecar_sup.erl
+++ b/apps/vmq_events_sidecar/src/vmq_events_sidecar_sup.erl
@@ -72,6 +72,13 @@ init([]) ->
     ChildSpecs =
         [
             #{
+                id => vmq_events_sidecar_metrics,
+                start => {vmq_events_sidecar_metrics, start_link, []},
+                restart => permanent,
+                type => worker,
+                modules => [vmq_events_sidecar_metrics]
+            },
+            #{
                 id => vmq_events_sidecar_plugin,
                 start => {vmq_events_sidecar_plugin, start_link, []},
                 restart => permanent,

--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -67,9 +67,6 @@
     incr_mqtt_error_subscribe/0,
     incr_mqtt_error_unsubscribe/0,
 
-    incr_sidecar_events/1,
-    incr_sidecar_events_error/1,
-
     incr_queue_setup/0,
     incr_queue_initialized_from_storage/0,
     incr_queue_teardown/0,
@@ -97,9 +94,6 @@
 
     incr_msg_enqueue_subscriber_not_found/0,
     incr_shared_subscription_group_publish_attempt_failed/0,
-
-    incr_events_sampled/2,
-    incr_events_dropped/2,
     update_config_version_metric/2
 ]).
 
@@ -129,7 +123,6 @@
 ]).
 
 -define(TIMER_TABLE, vmq_metrics_timers).
--define(EVENTS_SAMPLING_TABLE, vmq_metrics_events_sampling).
 -define(CONFIG_VERION_TABLE, config_version_table).
 
 -record(state, {
@@ -262,12 +255,6 @@ incr_qos1_non_retry_message_dropped() ->
 incr_qos1_non_persistence_message_dropped() ->
     incr_item(?QOS1_NON_PERSISTENCE_DROPPED, 1).
 
-incr_sidecar_events(HookName) ->
-    incr_item({?SIDECAR_EVENTS, HookName}, 1).
-
-incr_sidecar_events_error(HookName) ->
-    incr_item({?SIDECAR_EVENTS_ERROR, HookName}, 1).
-
 incr_queue_setup() ->
     incr_item(?METRIC_QUEUE_SETUP, 1).
 
@@ -335,29 +322,6 @@ incr_msg_enqueue_subscriber_not_found() ->
 
 incr_shared_subscription_group_publish_attempt_failed() ->
     incr_item(shared_subscription_group_publish_attempt_failed, 1).
-
--spec incr_events_sampled(hook_name(), Criterion :: binary() | undefined) -> ok.
-incr_events_sampled(_, undefined) -> ok;
-incr_events_sampled(H, C) -> incr_events_sampled_item(H, C, "sampled").
-
--spec incr_events_dropped(hook_name(), Criterion :: binary() | undefined) -> ok.
-incr_events_dropped(_, undefined) -> ok;
-incr_events_dropped(H, C) -> incr_events_sampled_item(H, C, "dropped").
-
-incr_events_sampled_item(H, C, SDType) ->
-    try
-        ets:update_counter(?EVENTS_SAMPLING_TABLE, {H, C, SDType}, 1)
-    catch
-        _:_ ->
-            try
-                ets:insert_new(?EVENTS_SAMPLING_TABLE, {{H, C, SDType}, 0}),
-                incr_events_sampled_item(H, C, SDType)
-            catch
-                _:_ ->
-                    lager:warning("couldn't initialize tables", [])
-            end
-    end,
-    ok.
 
 incr(Entry) ->
     incr_item(Entry, 1).
@@ -430,15 +394,13 @@ metrics(Opts) ->
 
     {PluggableMetricDefs, PluggableMetricValues} = pluggable_metrics(),
     {HistogramMetricDefs, HistogramMetricValues} = histogram_metrics(),
-    {EventsSamplingMetricsDefs, EventsSamplingMetricsValues} = events_sampling_metrics(),
     {ConfigVersionMetricsDefs, ConfigVersionMetricsValues} = config_version_metrics(),
 
     MetricDefs =
-        metric_defs() ++ PluggableMetricDefs ++ HistogramMetricDefs ++
-            EventsSamplingMetricsDefs ++ ConfigVersionMetricsDefs,
+        metric_defs() ++ PluggableMetricDefs ++ HistogramMetricDefs ++ ConfigVersionMetricsDefs,
     MetricValues =
         metric_values() ++ PluggableMetricValues ++ HistogramMetricValues ++
-            EventsSamplingMetricsValues ++ ConfigVersionMetricsValues,
+            ConfigVersionMetricsValues,
 
     %% Create id->metric def map
     IdDef = lists:foldl(
@@ -556,24 +518,6 @@ histogram_metrics() ->
         Histogram
     ).
 
-events_sampling_metric_defs() ->
-    {Defs, _} = events_sampling_metrics(),
-    Defs.
-
-events_sampling_metrics() ->
-    ets:foldl(
-        fun({{Hook, Criterion, SDType}, TotalCount}, {DefsAcc, ValsAcc}) ->
-            {UniqueId, MetricName, Description, Labels} = events_sampled_metric_name(
-                Hook, Criterion, SDType
-            ),
-            {[m(counter, Labels, UniqueId, MetricName, Description) | DefsAcc], [
-                {UniqueId, TotalCount} | ValsAcc
-            ]}
-        end,
-        {[], []},
-        ?EVENTS_SAMPLING_TABLE
-    ).
-
 incr_bucket_ops(V) when V =< 10 ->
     [{2, 1}, {3, 1}, {4, 1}, {5, 1}, {6, 1}, {7, 1}, {8, 1}, {9, 1}, {10, 1}, {11, 1}, {12, V}];
 incr_bucket_ops(V) when V =< 100 ->
@@ -683,7 +627,7 @@ get_label_info() ->
             end,
             #{},
             metric_defs() ++ pluggable_metric_defs() ++ histogram_metric_defs() ++
-                events_sampling_metric_defs() ++ config_version_metric_defs()
+                config_version_metric_defs()
         ),
     maps:to_list(LabelInfo).
 
@@ -721,7 +665,6 @@ init([]) ->
     NumEntries = length(lists:usort(Idxs)),
 
     ets:new(?TIMER_TABLE, [named_table, public, {write_concurrency, true}]),
-    ets:new(?EVENTS_SAMPLING_TABLE, [named_table, public, {write_concurrency, true}]),
     ets:new(?CONFIG_VERION_TABLE, [named_table, public, {write_concurrency, true}]),
 
     %% only alloc a new atomics array if one doesn't already exist!
@@ -981,7 +924,6 @@ internal_defs() ->
             mqtt5_pubcomp_received_def(),
             mqtt5_auth_sent_def(),
             mqtt5_auth_received_def(),
-            sidecar_events_def(),
             redis_def(),
             mqtt_disconnect_def()
         ],
@@ -1124,44 +1066,6 @@ redis_def() ->
             )
         ],
     REDIS_DEF_1 ++ REDIS_DEF_2 ++ REDIS_DEF_3.
-
-sidecar_events_def() ->
-    HOOKs =
-        [
-            ?ON_REGISTER,
-            ?ON_REGISTER_FAILED,
-            ?ON_PUBLISH,
-            ?ON_SUBSCRIBE,
-            ?ON_UNSUBSCRIBE,
-            ?ON_DELIVER,
-            ?ON_DELIVERY_COMPLETE,
-            ?ON_OFFLINE_MESSAGE,
-            ?ON_CLIENT_WAKEUP,
-            ?ON_CLIENT_OFFLINE,
-            ?ON_CLIENT_GONE,
-            ?ON_SESSION_EXPIRED,
-            ?ON_MESSAGE_DROP
-        ],
-    [
-        m(
-            counter,
-            [{mqtt_version, "4"}, {hook, rcn_to_str(HOOK)}],
-            {?SIDECAR_EVENTS, HOOK},
-            sidecar_events,
-            <<"The number of events sidecar hook attempts.">>
-        )
-     || HOOK <- HOOKs
-    ] ++
-        [
-            m(
-                counter,
-                [{mqtt_version, "4"}, {hook, rcn_to_str(HOOK)}],
-                {?SIDECAR_EVENTS_ERROR, HOOK},
-                sidecar_events_error,
-                <<"The number of times events sidecar hook call failed.">>
-            )
-         || HOOK <- HOOKs
-        ].
 
 counter_entries_def() ->
     [
@@ -2870,14 +2774,6 @@ metric_name({Metric, SubMetric}) ->
         "A histogram of the " ++ LMetric ++ " " ++ LSubMetric ++ " latency."
     ),
     {Name, Name, Description, []}.
-
-events_sampled_metric_name(H, C, SDType) ->
-    Name = list_to_atom("vmq_events_" ++ SDType),
-    Labels = [{hook, atom_to_list(H)}, {acl_name, C}],
-    Description = list_to_binary(
-        "The number of events " ++ SDType ++ " due to sampling enabled."
-    ),
-    {[Name | Labels], Name, Description, Labels}.
 
 config_version_metric_name({MetricName, Labels}) ->
     Description = list_to_binary("The current version of the config file."),


### PR DESCRIPTION
## Proposed Changes
This PR moves the events sidecar metrics code from vmq_server to events_sidecar for independent plugin deployments.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)
- [x] Refectoring

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging
