### PR TITLE
feat: track message drop QoS 0 on offline user

### DIFF
--- a/apps/rebar.config
+++ b/apps/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
     {lager, "3.9.2"},
-    {vernemq_dev, {git, "https://github.com/gojekfarm/vernemq_dev.git", {tag, "1.3.0"}}},
+    {vernemq_dev, {git, "https://github.com/gojekfarm/vernemq_dev.git", {tag, "1.4.0"}}},
     {cuttlefish, {git, "https://github.com/Kyorai/cuttlefish.git", {tag, "v3.4.0"}}},
     {clique, {git, "https://github.com/vernemq/clique.git", {ref, "213d60fe70cf2badb851f2392da184715c645546"}}},
     {vmq_enhanced_auth, {path, "vmq_enhanced_auth"}},

--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -1123,10 +1123,13 @@ insert_many(MsgsOrRefs, State) ->
 
 %% Offline Queue
 -spec insert(deliver() | msg_ref(), state()) -> state().
-insert(#deliver{qos = 0}, #state{sessions = Sessions} = State) when
+insert(
+    #deliver{qos = 0} = D, #state{id = SId, sessions = Sessions, session_id = SessionId} = State
+) when
     Sessions == #{}
 ->
     %% no session online, skip message for QoS0 Subscription
+    on_message_drop_hook(SId, D, ?USER_OFFLINE, SessionId),
     State;
 insert(#deliver{msg = #vmq_msg{non_persistence = true}}, #state{sessions = Sessions} = State) when
     Sessions == #{}
@@ -1134,10 +1137,14 @@ insert(#deliver{msg = #vmq_msg{non_persistence = true}}, #state{sessions = Sessi
     %% no session online, skip message for QoS1 with non_persistence Subscription
     _ = vmq_metrics:incr_qos1_non_persistence_message_dropped(),
     State;
-insert(#deliver{msg = #vmq_msg{qos = 0}}, #state{sessions = Sessions} = State) when
+insert(
+    #deliver{msg = #vmq_msg{qos = 0}} = D,
+    #state{id = SId, sessions = Sessions, session_id = SessionId} = State
+) when
     Sessions == #{}
 ->
     %% no session online, skip QoS0 message for QoS1 or QoS2 Subscription
+    on_message_drop_hook(SId, D, ?USER_OFFLINE, SessionId),
     State;
 insert(
     MsgOrRef,

--- a/rebar.config
+++ b/rebar.config
@@ -43,7 +43,8 @@
     {stdout_formatter, "0.2.3"},
     %% use specific cuttlefish commit until either 2.2.1 or 2.3.0 is relased.
     {cuttlefish, {git, "https://github.com/Kyorai/cuttlefish.git", {tag, "v2.3.0"}}},
-    {vernemq_dev, {git, "https://github.com/gojekfarm/vernemq_dev.git", {tag, "1.3.0"}}},
+    {vernemq_dev,
+        {git, "https://github.com/gojekfarm/vernemq_dev.git", {branch, "feature/user-offline"}}},
     {syslog, "1.1.0"},
     {lager_syslog, {git, "https://github.com/basho/lager_syslog.git", {tag, "3.1.1"}}},
     %% remove once clique hex package 3.0.2 is released

--- a/rebar.config
+++ b/rebar.config
@@ -43,8 +43,7 @@
     {stdout_formatter, "0.2.3"},
     %% use specific cuttlefish commit until either 2.2.1 or 2.3.0 is relased.
     {cuttlefish, {git, "https://github.com/Kyorai/cuttlefish.git", {tag, "v2.3.0"}}},
-    {vernemq_dev,
-        {git, "https://github.com/gojekfarm/vernemq_dev.git", {branch, "feature/user-offline"}}},
+    {vernemq_dev, {git, "https://github.com/gojekfarm/vernemq_dev.git", {tag, "1.4.0"}}},
     {syslog, "1.1.0"},
     {lager_syslog, {git, "https://github.com/basho/lager_syslog.git", {tag, "3.1.1"}}},
     %% remove once clique hex package 3.0.2 is released

--- a/rebar.lock
+++ b/rebar.lock
@@ -111,7 +111,7 @@
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.7.0">>},1},
  {<<"vernemq_dev">>,
   {git,"https://github.com/gojekfarm/vernemq_dev.git",
-       {ref,"109da8c0fc7d44c5571978a3293a161daab53bf4"}},
+       {ref,"d165a2e63be7216622f7338fad188bff1a9629e1"}},
   0}]}.
 [
 {pkg_hash,[

--- a/rebar.lock
+++ b/rebar.lock
@@ -111,7 +111,7 @@
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.7.0">>},1},
  {<<"vernemq_dev">>,
   {git,"https://github.com/gojekfarm/vernemq_dev.git",
-       {ref,"d165a2e63be7216622f7338fad188bff1a9629e1"}},
+       {ref,"9d5ce8eff3a90406743d4bd5bc8667f80c889b81"}},
   0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
## Proposed Changes

We want to track message drop that's caused by subscriber that has gone offline upon publishing QoS 0 message. When inserting to offline queue, before dropping the message, call on_message_drop hook with reason user_offline.

<img width="1491" height="805" alt="Screenshot 2026-05-24 at 21 21 30" src="https://github.com/user-attachments/assets/6fca17cb-0607-40b5-9a87-a08242806043" />

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)